### PR TITLE
Update npc_items_custom.txt

### DIFF
--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -4467,7 +4467,7 @@
 
 		"AbilityValues"
 		{
-			"bonus_attributes"				"40"
+			"bonus_attributes"				"65"
 			"unselect_attribute_pct"		"10"
 			"select_attribute_pct"			"6"
 		}


### PR DESCRIPTION
Ultimate orb подорожал в связи с апдейтом 7.35 и стал давать не 10 атрибутов, а 15 -> чтобы сохранить баланс надо добавить +25 ко всем атрибутам к уже имеющимся 40, по формуле 5 с каждого орба (у нас их всего 5) (т.к каждый орб стал давать на 5 больше)