### PR TITLE
Excalibur chance fix

### DIFF
--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -3175,7 +3175,7 @@
 			"bonus_mana_regen"		"3"
 			"damage"				"225"
 			"cleave"				"70"
-			"chance"				"25"
+			"chance"				"30"
 			"radius"				"650"
 		}
 	}


### PR DESCRIPTION
Excalibur proc chance 25% -> 30%

> Daedalus - пассивный шанс критов 30%, при сборке в Экскалибур шанс снижается(25%), что нелогично 

> + экскалибур заслуживает бафф т.к он за практически такую же цену слишком сильно уступает мемолятору в силе и поэтому берётся очень редко 