### PR TITLE
Create npc_popular_items.txt

### DIFF
--- a/game/scripts/npc/npc_popular_items.txt
+++ b/game/scripts/npc/npc_popular_items.txt
@@ -1,0 +1,5 @@
+"DOTAHeroes"
+{
+
+
+}


### PR DESCRIPTION
Нужно это для того, чтобы биржа, в гайде на герое не отображала дефолтные популярные предметы. Ведь нам это не нужно, по-скольку герои в нашей игре - кастомные. В будущем можно каждому герою приписать свои популярные итемы.