### PR TITLE
Burgers Buff

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -1263,7 +1263,7 @@
 //================================================================ ===================================================== ===============
 
 "DOTA_Tooltip_ability_item_burger_sobolev" 								"Sobolev Burger"
-"DOTA_Tooltip_ability_item_burger_sobolev_Description" 					"<h1>Use: Kusac</h1>Permanently adds %bonus_str% <font color='#FE4545'>Strength</font> to your hero and %resist%%% to effect resistance"
+"DOTA_Tooltip_ability_item_burger_sobolev_Description" 					"<h1>Use: Kusac</h1>Permanently adds %bonus_str% <font color='#FE4545'>Strength</font> to your hero and %resist%%% to status resistance"
 
 "DOTA_Tooltip_modifier_burger_strength" 									"Sobolev Burger"
 "DOTA_Tooltip_modifier_burger_strength_Description" 						"Number of burgers eaten"

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -685,7 +685,7 @@
 		"AbilityValues"
 		{
 			"bonus_agi"							"10"
-			"movespeed"							"1"
+			"movespeed"							"2"
 		}
 	}
 
@@ -707,7 +707,7 @@
 		"AbilityValues"
 		{
 			"bonus_int"							"10"
-			"spell_amplify"						"1"
+			"spell_amplify"						"1.75"
 		}
 	}
 	

--- a/game/scripts/vscripts/items/items_burgers.lua
+++ b/game/scripts/vscripts/items/items_burgers.lua
@@ -123,7 +123,7 @@ end
 
 function modifier_burger_agility:OnCreated()
     self.bonus = 10
-    self.movespeed = 1
+    self.movespeed = 2
 end
 
 function modifier_burger_agility:DeclareFunctions()
@@ -159,7 +159,7 @@ end
 
 function modifier_burger_intellect:OnCreated()
     self.bonus = 10
-    self.amplify = 1
+    self.amplify = 1.75
 end
 
 function modifier_burger_intellect:DeclareFunctions()


### PR DESCRIPTION
Исправлена английская локализация Бургера Соболева

Бургер Ларина:
>бонусный амплифай увеличен 1 -> 1.75

Бургер Обломова:
>бонусный мувспид увеличен 1 -> 2

(Бургерам Ларина и Обломова нужен был бафф т.к пока бургер соболева давал силу(самый полезный стат в доте) эти бургеры давали инту или ловкость, что не так важно, поэтому их никто не брал)