### PR TITLE
BRB-Pyramide fix

### DIFF
--- a/game/scripts/vscripts/abilities/heroes/bigrussianboss.lua
+++ b/game/scripts/vscripts/abilities/heroes/bigrussianboss.lua
@@ -712,6 +712,12 @@ function modifier_brb_test_damage:DeclareFunctions()
 end
 
 function modifier_brb_test_damage:GetModifierIncomingDamage_Percentage()
+    if self:GetParent():GetUnitName() == "npc_dota_hero_pyramide" then
+        return self.damage / 2
+    end
+    if self:GetParent():GetUnitName() == "npc_dota_hero_pyramide" and self:GetCaster():HasScepter() then
+        return self.damage / 4
+    end
     if self:GetParent() ~= self:GetCaster() and self:GetCaster():HasScepter() then
         return self.damage / 2
     end


### PR DESCRIPTION
Теперь при применении ульты БРБ на Пирамиду снижение входящего урона для Пирамиды в два раза меньше. 

По-скольку Пирамида имеет пассивку дающую 50% сопротивления, ульта БРБ без аганима теперь повысит сопротивление на 25%, а не на 50% как раньше, что давало ей 100% сопротивления к входящему урону